### PR TITLE
Add Architecture Decision Records

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+doc/decisions

--- a/doc/decisions/0001-record-architecture-decisions.md
+++ b/doc/decisions/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2022-06-10
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).


### PR DESCRIPTION
We will record our decisions as Architecture Decision Records [1] with
ADR Tools [2].

[1] http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
[2] https://github.com/npryce/adr-tools