### PR TITLE
Add Scripts To Rule Them All

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,11 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 
-# Ignore node_modules
-/node_modules
+# Dependencies
+/Brewfile.lock.json
+/.bundle/
+/node_modules/
+/vendor/bundle/
 
 # Ignore Rspec persisted failure list
 /spec/examples.txt

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,6 +251,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
 
 DEPENDENCIES
   bootsnap

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,17 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 0) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end

--- a/script/all/process-script-args
+++ b/script/all/process-script-args
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Source this in a script to process standard arguments for it.
+
+set -e
+
+echo "==> Loading command line options..."
+DOCKER=${PREFER_DOCKER_FOR_DXW_RAILS:-0}
+for arg in "$@"
+do
+  case $arg in
+    --docker)
+      DOCKER=1
+      ;;
+    --no-docker)
+      # shellcheck disable=SC2034
+      DOCKER=0
+      ;;
+    *)
+      # Stop processing arguments so we pass them on
+      break
+      ;;
+  esac
+  shift
+done

--- a/script/all/test
+++ b/script/all/test
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+# Run the test suite for the application. Optionally pass in a path to an
+# individual test file to run a single test.
+
+set -e
+
+TEST_FILES=$1
+
+if [ -n "$TEST_FILES" ]; then
+  echo "==> Running the tests matching '$TEST_FILES'..."
+  bundle exec rspec "$TEST_FILES"
+else
+  if [ -n "$AUTOMATICALLY_FIX_LINTING" ]; then
+    echo "==> Formatting files..."
+    yarn run lint:format:fix
+  else
+    echo "==> Checking formatting..."
+    yarn run lint:format
+  fi
+
+  echo "==> Running ShellCheck..."
+  for file in $(git ls-files script/*)
+  do
+    shellcheck -x "$file"
+  done
+
+  if [ -n "$AUTOMATICALLY_FIX_LINTING" ]; then
+    echo "==> Linting Ruby in fix mode..."
+    bundle exec standardrb --fix
+  else
+    echo "==> Linting Ruby..."
+    bundle exec standardrb
+  fi
+
+  if [ -n "$AUTOMATICALLY_FIX_LINTING" ]; then
+    echo "==> Linting JS in fix mode..."
+    yarn run lint:js:fix
+  else
+    echo "==> Linting JS..."
+    yarn run lint:js
+  fi
+
+  echo "==> Running the tests..."
+  bundle exec rspec
+
+  echo "==> Running Brakeman..."
+  bundle exec brakeman -o /dev/stdout
+fi

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# script/bootstrap: Resolve all dependencies that the application requires to
+#                   run.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/.."
+
+. script/all/process-script-args
+
+if [ "$DOCKER" -eq 1 ]; then
+  echo "==> Running with Docker..."
+  script/docker/bootstrap "$@"
+else
+  echo "==> Running natively (no docker)..."
+  script/no-docker/bootstrap "$@"
+fi

--- a/script/ci/cibuild
+++ b/script/ci/cibuild
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Setup environment for CI to run tests. This is primarily designed to run on
+# the continuous integration server.
+
+set -e
+
+docker-compose -f docker-compose.ci.yml -p app build

--- a/script/ci/test
+++ b/script/ci/test
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Run the test suite for the application. This is primarily designed to run on
+# CI with a clean build context. To run locally first remove any generic image
+# by running `docker rmi app:latest`
+
+set -e
+
+docker-compose -f docker-compose.ci.yml \
+               -p app \
+               run --rm test \
+               script/all/test "$@"

--- a/script/console
+++ b/script/console
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# script/console: Launch a console for the application. Use variables to control
+#                 how you want to provision your local environment.
+#                 Eg. `script/console --docker`
+#                 Or, add this as a global variable to your shell so it's set
+#                 automatically.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/.."
+
+. script/all/process-script-args
+
+if [ "$CI" ]; then
+  echo "==> Running as CI..."
+  script/ci/console
+elif [ "$DOCKER" -eq 1 ]; then
+  echo "==> Running with Docker..."
+  script/docker/console
+else
+  echo "==> Running natively (no docker)..."
+  script/no-docker/console
+fi

--- a/script/docker/bootstrap
+++ b/script/docker/bootstrap
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Resolve all dependencies that the application requires to run.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/../.."
+
+DOCKER_BUILD_ARGS=
+for arg in "$@"; do
+  case $arg in
+  --no-docker-cache)
+    DOCKER_BUILD_ARGS="--no-cache $DOCKER_BUILD_ARGS"
+    ;;
+  esac
+  shift
+done
+
+for file_and_image in docker-compose.yml:web docker-compose.test.yml:test; do
+  file=${file_and_image%:*}
+  image=${file_and_image#*:}
+
+  echo "==> Building $file_and_image Docker image..."
+  # shellcheck disable=SC2086
+  docker-compose -f $file build $DOCKER_BUILD_ARGS $image
+done

--- a/script/docker/console
+++ b/script/docker/console
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Launch a console for the application alongside any other required processes
+# inside Docker containers
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/../.."
+
+docker-compose run --rm web bundle exec rails console

--- a/script/docker/server
+++ b/script/docker/server
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Launch the application and any extra required processes locally in docker
+# containers.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/../.."
+
+# INFO: To enable debug prompts (with pry or byebug) we first start the process
+# in the background and then use attach to create an interactive prompt.
+docker-compose up --detach
+
+# TODO: Repace 'rails-template' with application name
+docker attach rails-template_web_1

--- a/script/docker/setup
+++ b/script/docker/setup
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Set up the application for the first time after cloning, or set it back to the
+# initial unused state.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/../.."
+
+echo "==> Tearing down any previous application state..."
+for file in docker-compose.yml docker-compose.test.yml; do
+  docker-compose -f $file down --rmi local --volumes --remove-orphans
+done
+
+script/docker/bootstrap --no-docker-cache

--- a/script/docker/test
+++ b/script/docker/test
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Run the test suite for the application in docker containers.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/../.."
+
+docker-compose -f docker-compose.test.yml \
+               run --rm test \
+               script/all/test "$@"

--- a/script/docker/update
+++ b/script/docker/update
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Update application to run for its current checkout.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/../.."
+
+echo "==> Bootstrapping..."
+script/docker/bootstrap

--- a/script/no-docker/bootstrap
+++ b/script/no-docker/bootstrap
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+# Resolve all dependencies that the application requires to run.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/../.."
+
+if [ -f .gitmodules ]; then
+  echo "==> Updating Git submodules..."
+  git submodule update --init
+fi
+
+if [ -z "$CI" ]; then
+  if [ -f Brewfile ] && [ "$(uname -s)" = "Darwin" ]; then
+    if ! brew bundle check >/dev/null 2>&1; then
+      echo "==> Installing Homebrew dependencies..."
+      brew bundle install --verbose --no-lock
+    fi
+  fi
+
+  if [ -f .ruby-version ]; then
+    eval "$(rbenv init -)"
+
+    if [ -z "$(rbenv version-name 2>/dev/null)" ]; then
+      echo "==> Installing Ruby..."
+      rbenv install --skip-existing
+      rbenv rehash
+    fi
+  fi
+
+  if [ -f .node-version ]; then
+    eval "$(nodenv init -)"
+
+    if [ -z "$(nodenv version-name 2>/dev/null)" ]; then
+      echo "==> Installing Node..."
+      nodenv install --skip-existing
+      nodenv rehash
+    fi
+  fi
+fi
+
+if ! command -v bundle >/dev/null 2>&1; then
+  echo "==> Installing Bundler..."
+  gem install bundler
+
+  if [ -z "$CI" ]; then
+    rbenv rehash
+  fi
+fi
+
+if ! bundle check >/dev/null 2>&1; then
+  echo "==> Installing Ruby dependencies..."
+  bundle config set --local path vendor/bundle
+  bundle install
+fi
+
+if [ -f package.json ]; then
+  if ! yarn check --verify-tree >/dev/null 2>&1; then
+    echo "==> Installing JS dependencies..."
+    yarn install
+  fi
+fi

--- a/script/no-docker/console
+++ b/script/no-docker/console
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Launch a console for the application. Optionally pass in an environment name
+# to connect to a console for that environment.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/../.."
+
+ENVIRONMENT=$1
+
+if [ -n "$ENVIRONMENT" ]; then
+  case "$ENVIRONMENT" in
+    *)
+      echo "Unknown environment '$ENVIRONMENT'"
+      exit 1
+      ;;
+  esac
+else
+  echo "==> Updating..."
+  script/no-docker/update
+
+  echo "==> Starting a local Rails console..."
+  bundle exec rails console
+fi

--- a/script/no-docker/server
+++ b/script/no-docker/server
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Launch the application and any extra required processes locally.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/../.."
+
+echo "==> Updating..."
+script/no-docker/update
+
+echo "==> Starting the development server..."
+bundle exec rails server

--- a/script/no-docker/setup
+++ b/script/no-docker/setup
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+# Set up the application for the first time after cloning, or set it back to the
+# initial unused state.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/../.."
+
+if [ -d vendor/bundle ]; then
+  echo "==> Cleaning installed Ruby dependencies..."
+  git clean -x --force -- vendor/bundle
+fi
+
+echo "==> Bootstrapping..."
+script/no-docker/bootstrap
+
+echo "==> Dropping database..."
+set +e
+bundle exec rails db:drop
+DB_DROP_RESULT=$?
+set -e
+
+if [ -z "$CI" ] && [ -n "$DB_DROP_RESULT" ]; then
+  printf "\\nDatabase drop failed. Continue anyway? [y/N] "
+  read -r
+
+  case $REPLY in
+    y | Y)
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+fi
+
+echo "==> Creating database..."
+bundle exec rails db:setup
+
+echo "==> Dropping test database..."
+set +e
+RAILS_ENV="test" bundle exec rails db:drop
+DB_DROP_RESULT=$?
+set -e
+
+if [ -z "$CI" ] && [ -n "$DB_DROP_RESULT" ]; then
+  printf "\\nDatabase drop failed. Continue anyway? [y/N] "
+  read -r
+
+  case $REPLY in
+    y | Y)
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+fi
+
+echo "==> Creating test database..."
+RAILS_ENV="test" bundle exec rails db:setup

--- a/script/no-docker/test
+++ b/script/no-docker/test
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Run the test suite for the application. Optionally pass in a path to an
+# individual test file to run a single test.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/../.."
+
+if [ -n "$DEBUG" ]; then
+  set -x
+fi
+
+echo "==> Updating..."
+script/no-docker/update
+
+AUTOMATICALLY_FIX_LINTING=true script/all/test "$@"

--- a/script/no-docker/update
+++ b/script/no-docker/update
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Update application to run for its current checkout.
+
+set -e
+
+echo "==> Bootstrapping..."
+script/no-docker/bootstrap
+
+echo "==> Running database migrations..."
+bundle exec rails db:migrate
+
+echo "==> Running test database migrations..."
+RAILS_ENV="test" bundle exec rails db:migrate

--- a/script/server
+++ b/script/server
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# script/server: Launch the application and any extra required processes
+#                locally. Use variables to control how you want to provision
+#                your local environment.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/.."
+
+. script/all/process-script-args
+
+if [ "$CI" ]; then
+  echo "==> Running as CI..."
+  script/ci/server
+elif [ "$DOCKER" -eq 1 ]; then
+  echo "==> Running with Docker..."
+  script/docker/server
+else
+  echo "==> Running natively (no docker)..."
+  script/no-docker/server
+fi

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# script/setup: Set up the application for the first time after cloning, or set
+#               it back to the initial unused state.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/.."
+
+. script/all/process-script-args
+
+if [ ! -f .env.development.local ]; then
+  echo "==> Copying default environment config..."
+  cp .env.example .env.development.local
+fi
+
+if [ "$DOCKER" -eq 1 ]; then
+  echo "==> Setting up with Docker..."
+  script/docker/setup "$@"
+else
+  echo "==> Settting up natively (no docker)..."
+  script/no-docker/setup "$@"
+fi

--- a/script/test
+++ b/script/test
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# script/test: Run the test suite for the application.
+#
+#              Optionally pass in a path to an individual test file to run a
+#              single test.
+#
+#              Use variables to control how you want to provision your local
+#              environment.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/.."
+
+. script/all/process-script-args
+
+if [ "$CI" ]; then
+  echo "==> Running as CI..."
+  script/ci/test "$@"
+elif [ "$DOCKER" -eq 1 ]; then
+  echo "==> Running with Docker..."
+  script/docker/test "$@"
+else
+  echo "==> Running natively (no docker)..."
+  script/no-docker/test "$@"
+fi

--- a/script/update
+++ b/script/update
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# script/update: Update application to run for its current checkout.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/.."
+
+. script/all/process-script-args
+
+if [ "$DOCKER" -eq 1 ]; then
+  echo "==> Running with Docker..."
+  script/docker/update "$@"
+else
+  echo "==> Running natively (no docker)..."
+  script/no-docker/update "$@"
+fi


### PR DESCRIPTION
As per [RFC 023](https://github.com/dxw/tech-team-rfcs/blob/main/rfc-023-use-scripts-to-rule-them-all.md), add the [Scripts To Rule Them All from our Rails template](https://github.com/dxw/rails-template/tree/develop/script).

This simplifies things like onboarding and maintaining dependencies, eg by allowing `script/setup` to install all necessary dependencies and perform tasks to bring a working environment up.