### PR TITLE
Add Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,2 @@
+brew "rbenv"
+brew "nodenv"


### PR DESCRIPTION
This specifies rbenv and nodenv as dependencies for Homebrew to install, simplifying the setup process to "install Homebrew, run `script/setup`".